### PR TITLE
Fixes for Qt6, HomeBrew, clang on macOS.

### DIFF
--- a/build-aux/autotroll.m4
+++ b/build-aux/autotroll.m4
@@ -59,7 +59,7 @@
 #
 #  - Add option `--without-qt', which is equivalent to `--with-qt=no'.
 #
-#  - On MacOS, add `-spec macx-g++' or 'spec macx-lang' (if $CXX --version
+#  - On MacOS, add `-spec macx-g++' or '-spec macx-lang' (if $CXX --version
 #    output contains "clang").  This can be overridden
 #    with the QMAKESPEC environment variable, for example
 #
@@ -224,8 +224,7 @@ AC_DEFUN([AT_WITH_QT],
      # Find Qt.
      AC_ARG_VAR([QT_PATH],
        [path to Qt binaries])
-     # HomeBrew installs into /usr/local/share/qt/libexec
-     QT_TOOL_PATH=$QT_PATH:$PATH:/usr/local/share/qt/libexec
+     QT_TOOL_PATH=$QT_PATH:$PATH
 
      # Find qmake.
      AC_ARG_VAR([QMAKE],

--- a/build-aux/autotroll.m4
+++ b/build-aux/autotroll.m4
@@ -59,7 +59,8 @@
 #
 #  - Add option `--without-qt', which is equivalent to `--with-qt=no'.
 #
-#  - On MacOS, add `-spec macx-g++' to qmake.  This can be overridden
+#  - On MacOS, add `-spec macx-g++' or 'spec macx-lang' (if $CXX --version
+#    output contains "clang").  This can be overridden
 #    with the QMAKESPEC environment variable, for example
 #
 #      QMAKESPEC='macx-clang' ./configure ...
@@ -223,6 +224,8 @@ AC_DEFUN([AT_WITH_QT],
      # Find Qt.
      AC_ARG_VAR([QT_PATH],
        [path to Qt binaries])
+     # HomeBrew installs into /usr/local/share/qt/libexec
+     QT_TOOL_PATH=$QT_PATH:$PATH:/usr/local/share/qt/libexec
 
      # Find qmake.
      AC_ARG_VAR([QMAKE],
@@ -230,7 +233,7 @@ AC_DEFUN([AT_WITH_QT],
      AX_PATH_TOOLS([QMAKE],
        [qmake qmake-qt5 qmake-qt4 qmake-qt3],
        [missing],
-       [$QT_PATH:$PATH])
+       [$QT_TOOL_PATH])
      if test x"$QMAKE" = xmissing; then
        AX_INSTEAD_IF([$4],
          [Cannot find qmake.  Try --with-qt=PATH.])
@@ -243,7 +246,7 @@ AC_DEFUN([AT_WITH_QT],
      AX_PATH_TOOLS([MOC],
        [moc moc-qt5 moc-qt4 moc-qt3],
        [missing],
-       [$QT_PATH:$PATH])
+       [$QT_TOOL_PATH])
      if test x"$MOC" = xmissing; then
        AX_INSTEAD_IF([$4],
          [Cannot find moc (Meta Object Compiler).  Try --with-qt=PATH.])
@@ -256,7 +259,7 @@ AC_DEFUN([AT_WITH_QT],
      AX_PATH_TOOLS([UIC],
        [uic uic-qt5 uic-qt4 uic-qt3 uic3],
        [missing],
-       [$QT_PATH:$PATH])
+       [$QT_TOOL_PATH])
      if test x"$UIC" = xmissing; then
        AX_INSTEAD_IF([$4],
          [Cannot find uic (User Interface Compiler).  Try --with-qt=PATH.])
@@ -269,7 +272,7 @@ AC_DEFUN([AT_WITH_QT],
      AX_PATH_TOOLS([RCC],
        [rcc rcc-qt5],
        [missing],
-       [$QT_PATH:$PATH])
+       [$QT_TOOL_PATH])
      if test x"$RCC" = xmissing; then
        AC_MSG_WARN(
          [Cannot find rcc (Qt Resource Compiler).  Try --with-qt=PATH.])
@@ -289,7 +292,11 @@ AC_DEFUN([AT_WITH_QT],
      AC_MSG_CHECKING([whether QMAKESPEC environment variable is set])
      if test x"$QMAKESPEC" = x; then
        if test x"$at_darwin" = xyes; then
-         at_qmake_args='-spec macx-g++'
+         if $CXX --version | grep -q -i clang; then
+           at_qmake_args='-spec macx-clang'
+         else
+           at_qmake_args='-spec macx-g++'
+         fi
          AC_MSG_RESULT([no, using $at_qmake_args])
        else
          AC_MSG_RESULT([no])
@@ -517,7 +524,7 @@ EOF
         : ${MAKE=make}
 
         if $MAKE >& AS_MESSAGE_LOG_FD 2>&1; then
-          at_cv_qt_build='ok, looks like Qt 4 or Qt 5'
+          at_cv_qt_build='ok, looks like Qt 4 or Qt 5 or Qt 6'
         else
           echo "$as_me:$LINENO: Build failed, trying to #include <qobject.h> instead" \
             >& AS_MESSAGE_LOG_FD


### PR DESCRIPTION
Has been tested with Qt6 on macOS/HomeBrew, and Qt 5 on Fedora.
- Search /usr/local/share/qt/libexec (used by HomeBrew) for tools.
- On macOS set -spec for clang if $CC is clang.